### PR TITLE
Added xrd, composition and claim for GCP Compute instance

### DIFF
--- a/Compositions/Compute/claim.yaml
+++ b/Compositions/Compute/claim.yaml
@@ -1,0 +1,47 @@
+apiVersion: zscaler.com/v1alpha1
+kind: GCPInstance
+metadata:
+  name: example-gcp-instance
+  namespace: default
+spec:
+  parameters:
+    gcpProfile:
+      project: temp-463509
+      region: us-central1
+      mgmtSubnet: my-management-subnet
+      dnsZoneName: my-dns-zone
+      dnsZoneDomain: example.com
+    instanceConfig:
+      name: my-vm
+      machineType: e2-medium
+      zone: us-central1-a
+      bootDiskType: pd-ssd
+      bootSize: 20
+      dataSize: 50
+      image: projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts
+      configureNlb: false
+      configurePfRule: false
+      noOfPfRule: 0
+      serviceType: NONE
+      zsCloud: global
+      interfaces:
+        - subnetwork: projects/temp-463509/regions/us-central1/subnetworks/prajna-client-subnet
+          nicType: VIRTIO_NET
+          aliasIps:
+            - 10.0.0.6
+      userData: |
+        #!/bin/bash
+        echo "Hello from VM"
+    instanceName: my-vm-fqdn
+    sshKeys:
+      - username: ubuntu
+        sshKey: ubuntu:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCn2GEgOoofkmtoJiIjuc3VC1fMsh59sg+j5e5MEEiE3h8HmcazHkml9Z0f0/jIKjiEHkMBGkWTA1KLbwKt6yX3GmiX2JWprRoTVxjoy/HmqHuYB7s3vwwvUnrZUqXgPzN7ZWyehe3yeGXCC/e2thzAfpcCNaDzAJ5rc/NFi/ZEv56rHyReFfyZIe2Mekm/HkbBgUQuYpzGyhSeiNGHpc3FUITjX9ozNeIy66oaUA6QP4siI0677dqoscQ2q093/ekZ6oLkibhywyzlnRmCa4IwtlOdexIkcZD6xXnEM9PJLAZgj+ahxofS2gbNFDKQ8dxuX3uxPjXi3iHjhgX9sNLjfvKALcZsxXwm3blANvmCRJBA2eRsMgmYf1O2udjbIhlTK1VwK5x2LSYzs4ptKtKHuphJZE9gApZBIQ+k7T4xJ14vB+JwBfhIuf9QjwbqVpG55AV0uEvqTkhE+ro6Q7jeazwkyQu1hxzQ+cs7dnSyPXhpi+agOSWl4n2K0gAKLXFHthox5qWCs8fwlnv27P0byo59KZaCCqzFWrZU3AtHii8XrIuzQ8ndZMW8tMlz6hjImPoOw+maeSA0yPZbB4cn5QZUMfO7N0La+1CkIUs/0HHROJZoV6nDzKJHYTDMoWlAO+16WSpp8NH9Yt2pZITTcwPp/G8ubRWcDU0XeRT7aQ== palprajna2002@gmail.com
+    subnetNames:
+      client: prajna-client-subnet
+      server: prajna-server-subnet
+      cloud: prajna-cloud-subnet
+    tags:
+      - prajna-vm
+    createDnsRecord: true
+  writeConnectionSecretToRef:
+    name: gcp-instance-creds

--- a/Compositions/Compute/composition.yaml
+++ b/Compositions/Compute/composition.yaml
@@ -1,0 +1,72 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xgcpinstance-beginner-pipeline
+spec:
+  writeConnectionSecretsToNamespace: crossplane-system
+
+  compositeTypeRef:
+    apiVersion: zscaler.com/v1alpha1
+    kind: XGCPInstance
+
+  resources:
+    - name: vm
+      base:
+        apiVersion: compute.gcp.upbound.io/v1beta1
+        kind: Instance
+        spec:
+          providerConfigRef:
+            name: default
+          forProvider:
+            bootDisk:
+              - initializeParams:
+                  - {}
+            networkInterface:
+              - accessConfig:
+                  - {}    # <--- This adds a public IP
+          writeConnectionSecretToRef:
+            name: ""
+            namespace: crossplane-system
+
+      patches:
+        - fromFieldPath: metadata.name
+          toFieldPath: spec.writeConnectionSecretToRef.name
+
+        - fromFieldPath: spec.parameters.instanceConfig.machineType
+          toFieldPath: spec.forProvider.machineType
+
+        - fromFieldPath: spec.parameters.instanceConfig.zone
+          toFieldPath: spec.forProvider.zone
+
+        - fromFieldPath: spec.parameters.instanceConfig.image
+          toFieldPath: spec.forProvider.bootDisk[0].initializeParams[0].image
+
+        - fromFieldPath: spec.parameters.instanceConfig.bootDiskType
+          toFieldPath: spec.forProvider.bootDisk[0].initializeParams[0].type
+
+        - fromFieldPath: spec.parameters.instanceConfig.bootSize
+          toFieldPath: spec.forProvider.bootDisk[0].initializeParams[0].size
+
+        - fromFieldPath: spec.parameters.instanceConfig.interfaces[0].subnetwork
+          toFieldPath: spec.forProvider.networkInterface[0].subnetwork
+
+        - fromFieldPath: spec.parameters.instanceConfig.interfaces[0].nicType
+          toFieldPath: spec.forProvider.networkInterface[0].nicType
+
+        # SSH keys patch (formats as: username:ssh-rsa....)
+        - fromFieldPath: spec.parameters.sshKeys[0].sshKey
+          toFieldPath: spec.forProvider.metadata.ssh-keys
+
+        - fromFieldPath: spec.parameters.instanceConfig.userData
+          toFieldPath: spec.forProvider.metadata.user-data
+
+        - fromFieldPath: spec.parameters.tags
+          toFieldPath: spec.forProvider.tags
+
+      connectionDetails:
+        - fromFieldPath: status.atProvider.networkInterface[0].networkIp
+          name: ipAddress
+        - fromFieldPath: status.atProvider.networkInterface[0].accessConfig[0].natIp
+          name: publicIp
+        - fromConnectionSecretKey: ssh-keys
+          name: sshKey

--- a/Compositions/Compute/xrd.yaml
+++ b/Compositions/Compute/xrd.yaml
@@ -1,0 +1,153 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xgcpinstances.zscaler.com
+spec:
+  # 1) Automatically bind this Composition by default:
+  defaultCompositionRef:
+    name: xgcpinstance-beginner-pipeline
+
+  # 2) Only expose these keys in the Connection Secret:
+  connectionSecretKeys:
+    - ipAddress
+    - sshKey
+
+  group: zscaler.com
+  names:
+    kind: XGCPInstance
+    plural: xgcpinstances
+  claimNames:
+    kind: GCPInstance
+    plural: gcpinstances
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  properties:
+                    gcpProfile:
+                      type: object
+                      properties:
+                        project:
+                          type: string
+                        region:
+                          type: string
+                        mgmtSubnet:
+                          type: string
+                        dnsZoneName:
+                          type: string
+                        dnsZoneDomain:
+                          type: string
+                      required:
+                        - project
+                        - region
+                        - mgmtSubnet
+                        - dnsZoneName
+                        - dnsZoneDomain
+                    instanceConfig:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        machineType:
+                          type: string
+                        zone:
+                          type: string
+                        bootDiskType:
+                          type: string
+                        bootSize:
+                          type: integer
+                        dataSize:
+                          type: integer
+                        image:
+                          type: string
+                        configureNlb:
+                          type: boolean
+                        configurePfRule:
+                          type: boolean
+                        noOfPfRule:
+                          type: integer
+                        serviceType:
+                          type: string
+                        zsCloud:
+                          type: string
+                        interfaces:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              subnetwork:
+                                type: string
+                              ipaddress:
+                                type: string
+                              nicType:
+                                type: string
+                              aliasIps:
+                                type: array
+                                items:
+                                  type: string
+                            required:
+                              - subnetwork
+                        userData:
+                          type: string
+                      required:
+                        - name
+                        - machineType
+                        - zone
+                        - bootDiskType
+                        - bootSize
+                        - dataSize
+                        - image
+                    instanceName:
+                      type: string
+                    sshKeys:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          username:
+                            type: string
+                          sshKey:
+                            type: string
+                        required:
+                          - username
+                          - sshKey
+                    subnetNames:
+                      type: object
+                      properties:
+                        client:
+                          type: string
+                        server:
+                          type: string
+                        cloud:
+                          type: string
+                      required:
+                        - client
+                        - server
+                        - cloud
+                    tags:
+                      type: array
+                      items:
+                        type: string
+                    createDnsRecord:
+                      type: boolean
+                  required:
+                    - gcpProfile
+                    - instanceConfig
+                    - instanceName
+                    - sshKeys
+                    - subnetNames
+                    - tags
+                    - createDnsRecord
+              required:
+                - parameters
+          required:
+            - spec


### PR DESCRIPTION
Adds the Crossplane configuration for provisioning a GCP Compute Instance.  
Includes:

- `xrd.yaml`: Defines the GCPInstance XRD with input parameters.
- `composition.yaml`: Maps the XRD to a GCP VM using Upbound's provider.
- `claim.yaml`: Sample claim to provision the instance.

Files are placed under `compositions/Compute/`.
